### PR TITLE
Update to Secure Hash Algorithm to avoid MD5 Jeff Collisions

### DIFF
--- a/hash.rb
+++ b/hash.rb
@@ -1,9 +1,7 @@
-require 'digest/md5'
+require 'digest/sha2'
 
-jeff = 'abd7f453bd7c4bfee0824cf1546b6cd8'
 f = './jeff.jpg'
-
-digest = Digest::MD5.hexdigest(File.read(f))
+digest = Digest::SHA2.new(512).hexdigest(File.read(f))
 
 if jeff == digest
   puts 'Success, Jeff is validated'

--- a/hash.rb
+++ b/hash.rb
@@ -1,5 +1,6 @@
 require 'digest/sha2'
 
+jeff = '63a9e0dfe75cea22554b04fc18055209719cb03860ee93ff444a47c7295ab072c4d43b7e36e4151d70d7f0f26cc2328947d38e335b206a4a825eedc872f384e0'
 f = './jeff.jpg'
 digest = Digest::SHA2.new(512).hexdigest(File.read(f))
 


### PR DESCRIPTION
While MD5 may provide some protections in securing Jeff, please consider how an attacker could use existing vectors to alter the original Jeff and still produce an identical MD5 checksum. 

Please refer to [the following paper](https://eprint.iacr.org/2014/871.pdf) by Anton A. Kuznetsov demonstrating how it is possible to cause single-block collisions using high performance computing clusters and compromise a Goldblum.